### PR TITLE
Fix i386 again

### DIFF
--- a/i686/msvcrt.def
+++ b/i686/msvcrt.def
@@ -1481,7 +1481,7 @@ _wstat32=muxcrt.___phyx__wstat
 
 _stat=muxcrt.___phyx__stat
 _stat64=muxcrt.___phyx__stat64
-_stati64muxcrt.___phyx__stat64
+_stati64=muxcrt.___phyx__stat64
 _stat32=muxcrt.___phyx__stat
 
 rename=muxcrt.___phyx_rename


### PR DESCRIPTION
There was a missing equals sign in the 32-bit definitions file.